### PR TITLE
decode bytes so it can be print with Python 3

### DIFF
--- a/lib/activepapers/cli.py
+++ b/lib/activepapers/cli.py
@@ -507,7 +507,7 @@ def refs(paper, verbose):
     paper.close()
     sorted_refs = sorted(refs.keys())
     for ref in sorted_refs:
-        sys.stdout.write(ref + '\n')
+        sys.stdout.write(ref.decode('utf-8') + '\n')
         if verbose:
             links, copies = refs[ref]
             if links:


### PR DESCRIPTION
Python3 bug: 'aptool refs' could not print the references 